### PR TITLE
update newPosition constructor

### DIFF
--- a/projects/ngx-widget-grid/src/lib/components/grid/grid.component.ts
+++ b/projects/ngx-widget-grid/src/lib/components/grid/grid.component.ts
@@ -232,7 +232,7 @@ export class NgxWidgetGridComponent implements AfterViewInit {
   emitUpdatePosition(widget: WidgetConfig) {
     this.widgetPositionChange.emit({
                                      index: this.getWidgetIndex(widget),
-                                     newPosition: widget.position
+                                     newPosition: new Rectangle(widget.position)
                                    });
   }
 


### PR DESCRIPTION
Hello!
```
[x] bug
[ ] feature request
[ ] enhancement
```

### Expected behavior
Get updated value of newPosition from `widgetPositionChange()` after widget is moved.

### Actual behavior
Position values don't update after move. 

### Reproduction of behavior
I get value for `[position]` (`<ngx-widget>`) from function.  Example: 
```
// template 
<ngx-widget 
   *ngFor="let widget of widgets;let $index = index;" 
   [position]="getPosition($index)" // <---------------- this
></ngx-widget>

//component
 public getPosition(index: number) {
   return {top: 1, left: index, height: 1, width: 1};
 }
```
After widget is moved, I get newPosition from `(widgetPositionChange)`. Value of `newPosition` don't update, I get old values. 

_It looks good_
<img width="583" alt="Screenshot 2019-12-26 at 4 34 18 pm" src="https://user-images.githubusercontent.com/31247267/71478345-22f7d600-2800-11ea-80e8-fc79d6ab947f.png">

_But real values_
<img width="579" alt="Screenshot 2019-12-26 at 4 34 28 pm" src="https://user-images.githubusercontent.com/31247267/71478349-27bc8a00-2800-11ea-8bbd-a428e988b494.png">

### Additionally

When I debugged, I found main assignment for new position in `NgxWidgetMoverDirective` - `onUp`. I see, that `this.widgetCmp` position value and `this.widgetCmp.position` are different.

_this string_

<img width="395" alt="Screenshot 2019-12-26 at 5 13 30 pm" src="https://user-images.githubusercontent.com/31247267/71478922-1fb21980-2803-11ea-8272-c3bc8d03f39e.png">

_result_
<img width="591" alt="Screenshot 2019-12-26 at 5 00 49 pm" src="https://user-images.githubusercontent.com/31247267/71478886-eb3e5d80-2802-11ea-9608-6e8bffa70c1f.png">

I think, there is a bug here. I tried to fix it, but found only one way, that went into this PR.

### Environment details

- Angular version: 6 - 7
- OS and version: Mac OS
- Browser: [all]